### PR TITLE
Fix Supabase server cookie adapter

### DIFF
--- a/lib/supabase/server.tsx
+++ b/lib/supabase/server.tsx
@@ -1,8 +1,28 @@
-import { getSupabaseServerClient } from "@supabase/ssr"
+import { cookies } from "next/headers"
+import { createServerClient } from "@supabase/ssr"
 
 export { createServerClient } from "@supabase/ssr"
 
+export function getSupabaseServerClient() {
+  const cookieStore = cookies()
+
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll()
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value, options }) => {
+            cookieStore.set(name, value, options)
+          })
+        },
+      },
+    },
+  )
+}
+
 // Re-export the main function as createClient for compatibility
 export const createClient = getSupabaseServerClient
-
-// ... rest of code here ...


### PR DESCRIPTION
## Summary
- replace the stubbed Supabase server helper with a call to `createServerClient` configured for Next.js cookies
- implement the supported `CookieMethodsServer` surface using `getAll`/`setAll` and propagate cookie options when setting

## Testing
- npx tsc --noEmit *(fails: pre-existing JSX syntax errors in app/dashboard/analytics/transactions/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cdf202c3ec8331af5f143d4e419e9b