### PR TITLE
Add Plaid item transaction sync helper

### DIFF
--- a/lib/plaid-service.ts
+++ b/lib/plaid-service.ts
@@ -150,6 +150,20 @@ export class PlaidService {
     }
   }
 
+  async syncItemTransactionsByItemId(itemId: string): Promise<void> {
+    const { data: plaidItem } = await (await this.supabase())
+      .from("plaid_items")
+      .select("id, access_token")
+      .eq("item_id", itemId)
+      .single()
+
+    if (!plaidItem) return
+
+    const accessToken = decryptFromString(plaidItem.access_token)
+
+    await this.syncTransactions(accessToken, plaidItem.id)
+  }
+
   // Full transaction sync (initial sync)
   private async fullTransactionSync(accessToken: string, plaidItemId: string): Promise<void> {
     const startDate = new Date()


### PR DESCRIPTION
## Summary
- add a Plaid service helper that retrieves an item by Plaid item_id and synchronizes its transactions using the stored access token

## Testing
- pnpm lint *(fails: Next.js prompts to configure ESLint in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdf2b733b48331a9bd52e594095b3c