### PR TITLE
Update Supabase server client cookie adapter

### DIFF
--- a/lib/supabase/server.tsx
+++ b/lib/supabase/server.tsx
@@ -1,8 +1,31 @@
-import { getSupabaseServerClient } from "@supabase/ssr"
+import { createServerClient as createSupabaseServerClient } from "@supabase/ssr"
+import type { CookieMethodsServer } from "@supabase/ssr"
+import { cookies } from "next/headers"
 
-export { createServerClient } from "@supabase/ssr"
+function createSupabaseServerCookies(): CookieMethodsServer {
+  const cookieStore = cookies()
+
+  return {
+    getAll() {
+      return cookieStore.getAll().map(({ name, value }) => ({ name, value }))
+    },
+    setAll(cookiesToSet) {
+      cookiesToSet.forEach(({ name, value, options }) => {
+        cookieStore.set({ name, value, ...options })
+      })
+    },
+  }
+}
+
+export function createServerClient() {
+  return createSupabaseServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: createSupabaseServerCookies(),
+    },
+  )
+}
 
 // Re-export the main function as createClient for compatibility
-export const createClient = getSupabaseServerClient
-
-// ... rest of code here ...
+export const createClient = createServerClient


### PR DESCRIPTION
## Summary
- wrap the Supabase server client creation with a Next.js cookie adapter using the modern getAll/setAll contract
- ensure cookies are written via cookies().set with provided options and expose a convenience createClient alias

## Testing
- npx tsc --noEmit --skipLibCheck lib/supabase/server.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cdf2ac8a2083318ef93745aef838ad