### PR TITLE
Align toast theme with app theme tokens

### DIFF
--- a/components/toast/theme.css
+++ b/components/toast/theme.css
@@ -1,14 +1,11 @@
-:root {
-  --toast-bg: #ffffff;
-  --toast-fg: #111827;
-  --toast-border: #e5e7eb;
-  --toast-success: #10b981;
-  --toast-error: #ef4444;
-  --toast-info: #3b82f6;
-}
-
-[data-theme="dark"] {
-  --toast-bg: #111827;
-  --toast-fg: #f9fafb;
-  --toast-border: #374151;
+:root,
+:root[data-theme="dark"],
+.dark,
+.oled {
+  --toast-bg: var(--card);
+  --toast-fg: var(--card-foreground);
+  --toast-border: var(--border);
+  --toast-success: var(--chart-1);
+  --toast-error: var(--destructive);
+  --toast-info: var(--primary);
 }


### PR DESCRIPTION
## Summary
- update toast theme CSS variables to derive from global theme tokens
- ensure toast variables respond to class-based dark and OLED themes

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cdf350b49883318e2d75ebde0fdbc3