### PR TITLE
Sanitize Supabase server headers and add regression test

### DIFF
--- a/lib/supabase/server.tsx
+++ b/lib/supabase/server.tsx
@@ -1,15 +1,68 @@
-import { cookies } from "next/headers"
+import { cookies, headers } from "next/headers"
 import { createServerClient } from "@supabase/ssr"
+
+const AUTH_HEADER_DENYLIST = new Set(["authorization", "apikey", "x-supabase-api-key"])
+
+type HeaderLike =
+  | Iterable<[string, string]>
+  | Record<string, string>
+  | { forEach: (callback: (value: string, key: string) => void) => void }
+  | undefined
+
+export function stripAuthHeaders(headersInit: HeaderLike): Record<string, string> {
+  if (!headersInit) {
+    return {}
+  }
+
+  const sanitized: Record<string, string> = {}
+
+  const appendIfAllowed = (key: string, value: string) => {
+    const normalizedKey = key.toLowerCase()
+    if (!AUTH_HEADER_DENYLIST.has(normalizedKey)) {
+      sanitized[key] = value
+    }
+  }
+
+  if (typeof (headersInit as { forEach?: unknown }).forEach === "function" && !Array.isArray(headersInit)) {
+    ;(headersInit as { forEach: (callback: (value: string, key: string) => void) => void }).forEach(
+      (value, key) => {
+        appendIfAllowed(key, value)
+      },
+    )
+    return sanitized
+  }
+
+  if (Symbol.iterator in Object(headersInit)) {
+    for (const [key, value] of headersInit as Iterable<[string, string]>) {
+      appendIfAllowed(key, value)
+    }
+    return sanitized
+  }
+
+  Object.entries(headersInit as Record<string, string>).forEach(([key, value]) => {
+    appendIfAllowed(key, value)
+  })
+
+  return sanitized
+}
+
+export function getRequestHeaders() {
+  return stripAuthHeaders(headers())
+}
 
 export { createServerClient } from "@supabase/ssr"
 
 export function getSupabaseServerClient() {
   const cookieStore = cookies()
+  const requestHeaders = getRequestHeaders()
 
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
+      global: {
+        headers: requestHeaders,
+      },
       cookies: {
         getAll() {
           return cookieStore.getAll()

--- a/tests/supabase-server.test.ts
+++ b/tests/supabase-server.test.ts
@@ -1,0 +1,43 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { stripAuthHeaders } from "@/lib/supabase/server"
+
+test("stripAuthHeaders removes auth-conflicting headers", () => {
+  const headerPairs: Array<[string, string]> = [
+    ["Authorization", "Bearer fake"],
+    ["apikey", "supabase"],
+    ["X-Trace-Id", "abc"],
+  ]
+  const sanitized = stripAuthHeaders(headerPairs)
+
+  const lowerCaseKeys = Object.keys(sanitized).map((key) => key.toLowerCase())
+  assert.equal(lowerCaseKeys.includes("authorization"), false)
+  assert.equal(lowerCaseKeys.includes("apikey"), false)
+  assert.deepEqual(sanitized, { "X-Trace-Id": "abc" })
+})
+
+test("stripAuthHeaders preserves non-conflicting headers from Headers input", () => {
+  const incoming = new Headers()
+  incoming.set("Authorization", "Bearer something")
+  incoming.set("apikey", "key")
+  incoming.set("X-Client-Info", "custom-client")
+  incoming.set("x-request-id", "req-1")
+
+  const sanitized = stripAuthHeaders(incoming)
+
+  assert.ok(!("authorization" in sanitized))
+  assert.ok(!("apikey" in sanitized))
+  assert.equal(sanitized["x-client-info"], "custom-client")
+  assert.equal(sanitized["x-request-id"], "req-1")
+})
+
+test("stripAuthHeaders handles plain object input", () => {
+  const sanitized = stripAuthHeaders({
+    Authorization: "Bearer should-go",
+    apikey: "should-go",
+    "X-Request-Id": "req-2",
+  })
+
+  assert.deepEqual(sanitized, { "X-Request-Id": "req-2" })
+})


### PR DESCRIPTION
## Summary
- sanitize request headers before creating the Supabase server client so conflicting auth headers like Authorization or apikey are removed
- expose a reusable helper that filters unsafe headers and reuse it in getRequestHeaders when wiring the client
- add a regression test that covers the header stripping logic for tuple, Headers, and object inputs

## Testing
- `pnpm exec node --test --import tsx tests/supabase-server.test.ts`
- `pnpm lint` *(fails: Next.js cannot find a local eslint installation in this environment)*
- `pnpm exec tsc -p tsconfig.json --noEmit --pretty false` *(fails: numerous pre-existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cdf51855548331b95e61d7f079de6a